### PR TITLE
[SQUQASH-ME] qa/tasks/vstart_runner.py: s/StringIO/BytesIO/

### DIFF
--- a/qa/tasks/admin_socket.py
+++ b/qa/tasks/admin_socket.py
@@ -1,13 +1,13 @@
 """
 Admin Socket task -- used in rados, powercycle, and smoke testing
 """
-from cStringIO import StringIO
 
 import json
 import logging
 import os
 import time
 
+from teuthology.exceptions import CommandFailedError
 from teuthology.orchestra import run
 from teuthology import misc as teuthology
 from teuthology.parallel import parallel
@@ -84,31 +84,26 @@ def _socket_command(ctx, remote, socket_path, command, args):
 
     :returns: output of command in json format
     """
-    json_fp = StringIO()
     testdir = teuthology.get_testdir(ctx)
     max_tries = 120
     while True:
-        proc = remote.run(
-            args=[
+        try:
+            out = remote.sh([
                 'sudo',
                 'adjust-ulimits',
                 'ceph-coverage',
                 '{tdir}/archive/coverage'.format(tdir=testdir),
                 'ceph',
                 '--admin-daemon', socket_path,
-                ] + command.split(' ') + args,
-            stdout=json_fp,
-            check_status=False,
-            )
-        if proc.exitstatus == 0:
-            break
-        assert max_tries > 0
-        max_tries -= 1
-        log.info('ceph cli returned an error, command not registered yet?')
-        log.info('sleeping and retrying ...')
-        time.sleep(1)
-    out = json_fp.getvalue()
-    json_fp.close()
+                ] + command.split(' ') + args)
+        except CommandFailedError:
+            assert max_tries > 0
+            max_tries -= 1
+            log.info('ceph cli returned an error, command not registered yet?')
+            log.info('sleeping and retrying ...')
+            time.sleep(1)
+            continue
+        break
     log.debug('admin socket command %s returned %s', command, out)
     return json.loads(out)
 

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -605,7 +605,7 @@ def cluster(ctx, config):
             log.info('fs option selected, checking for scratch devs')
             log.info('found devs: %s' % (str(devs),))
             devs_id_map = teuthology.get_wwn_id_map(remote, devs)
-            iddevs = devs_id_map.values()
+            iddevs = list(devs_id_map.values())
             roles_to_devs = assign_devs(
                 teuthology.cluster_roles_of_type(roles_for_host, 'osd', cluster_name), iddevs
             )

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -19,14 +19,14 @@ import six
 import socket
 
 from paramiko import SSHException
-from ceph_manager import CephManager, write_conf
+from tasks.ceph_manager import CephManager, write_conf
 from tarfile import ReadError
 from tasks.cephfs.filesystem import Filesystem
 from teuthology import misc as teuthology
 from teuthology import contextutil
 from teuthology import exceptions
 from teuthology.orchestra import run
-import ceph_client as cclient
+import tasks.ceph_client as cclient
 from teuthology.orchestra.daemon import DaemonGroup
 from tasks.daemonwatchdog import DaemonWatchdog
 

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -3,7 +3,7 @@ Ceph cluster task.
 
 Handle the setup, starting, and clean-up of a Ceph cluster.
 """
-from cStringIO import StringIO
+from io import BytesIO
 
 import argparse
 import configobj
@@ -15,6 +15,7 @@ import json
 import time
 import gevent
 import re
+import six
 import socket
 
 from paramiko import SSHException
@@ -189,24 +190,26 @@ def ceph_log(ctx, config):
 
     def write_rotate_conf(ctx, daemons):
         testdir = teuthology.get_testdir(ctx)
+        remote_logrotate_conf = '%s/logrotate.ceph-test.conf' % testdir
         rotate_conf_path = os.path.join(os.path.dirname(__file__), 'logrotate.conf')
         with open(rotate_conf_path, 'rb') as f:
             conf = ""
             for daemon, size in daemons.items():
-                log.info('writing logrotate stanza for {daemon}'.format(daemon=daemon))
-                conf += f.read().format(daemon_type=daemon, max_size=size)
+                log.info('writing logrotate stanza for {}'.format(daemon))
+                conf += six.ensure_str(f.read()).format(daemon_type=daemon,
+                                                   max_size=size)
                 f.seek(0, 0)
 
             for remote in ctx.cluster.remotes.keys():
                 teuthology.write_file(remote=remote,
-                                      path='{tdir}/logrotate.ceph-test.conf'.format(tdir=testdir),
-                                      data=StringIO(conf)
+                                      path=remote_logrotate_conf,
+                                      data=BytesIO(conf.encode())
                                       )
                 remote.run(
                     args=[
                         'sudo',
                         'mv',
-                        '{tdir}/logrotate.ceph-test.conf'.format(tdir=testdir),
+                        remote_logrotate_conf,
                         '/etc/logrotate.d/ceph-test.conf',
                         run.Raw('&&'),
                         'sudo',
@@ -311,27 +314,20 @@ def valgrind_post(ctx, config):
         for remote in ctx.cluster.remotes.keys():
             # look at valgrind logs for each node
             proc = remote.run(
-                args=[
-                    'sudo',
-                    'zgrep',
-                    '<kind>',
-                    run.Raw('/var/log/ceph/valgrind/*'),
-                    '/dev/null',  # include a second file so that we always get a filename prefix on the output
-                    run.Raw('|'),
-                    'sort',
-                    run.Raw('|'),
-                    'uniq',
-                ],
+                args='sudo zgrep <kind> /var/log/ceph/valgrind/* '
+                     # include a second file so that we always get
+                     # a filename prefix on the output
+                     '/dev/null | sort | uniq',
                 wait=False,
                 check_status=False,
-                stdout=StringIO(),
+                stdout=BytesIO(),
             )
             lookup_procs.append((proc, remote))
 
         valgrind_exception = None
         for (proc, remote) in lookup_procs:
             proc.wait()
-            out = proc.stdout.getvalue()
+            out = six.ensure_str(proc.stdout.getvalue())
             for line in out.split('\n'):
                 if line == '':
                     continue
@@ -537,11 +533,7 @@ def create_simple_monmap(ctx, remote, conf, mons,
         path
     ])
 
-    r = remote.run(
-        args=args,
-        stdout=StringIO()
-    )
-    monmap_output = r.stdout.getvalue()
+    monmap_output = remote.sh(args)
     fsid = re.search("generated fsid (.+)$",
                      monmap_output, re.MULTILINE).group(1)
     return fsid
@@ -907,13 +899,7 @@ def cluster(ctx, config):
                 mkfs = ['mkfs.%s' % fs] + mkfs_options
                 log.info('%s on %s on %s' % (mkfs, dev, remote))
                 if package is not None:
-                    remote.run(
-                        args=[
-                            'sudo',
-                            'apt-get', 'install', '-y', package
-                        ],
-                        stdout=StringIO(),
-                    )
+                    remote.sh('sudo apt-get install -y %s' % package)
 
                 try:
                     remote.run(args=['yes', run.Raw('|')] + ['sudo'] + mkfs + [dev])
@@ -1001,7 +987,7 @@ def cluster(ctx, config):
                          'probably installing hammer: %s', e)
 
     log.info('Reading keys from all nodes...')
-    keys_fp = StringIO()
+    keys_fp = BytesIO()
     keys = []
     for remote, roles_for_host in ctx.cluster.remotes.items():
         for type_ in ['mgr',  'mds', 'osd']:
@@ -1038,7 +1024,7 @@ def cluster(ctx, config):
         ],
         stdin=run.PIPE,
         wait=False,
-        stdout=StringIO(),
+        stdout=BytesIO(),
     )
     keys_fp.seek(0)
     teuthology.feed_many_stdins_and_close(keys_fp, writes)
@@ -1140,14 +1126,8 @@ def cluster(ctx, config):
             args.extend([
                 run.Raw('|'), 'head', '-n', '1',
             ])
-            r = mon0_remote.run(
-                stdout=StringIO(),
-                args=args,
-            )
-            stdout = r.stdout.getvalue()
-            if stdout != '':
-                return stdout
-            return None
+            stdout = mon0_remote.sh(args)
+            return stdout or None
 
         if first_in_ceph_log('\[ERR\]|\[WRN\]|\[SEC\]',
                              config['log_whitelist']) is not None:
@@ -1364,11 +1344,11 @@ def run_daemon(ctx, config, type_):
             if type_ == 'osd':
                 datadir='/var/lib/ceph/osd/{cluster}-{id}'.format(
                     cluster=cluster_name, id=id_)
-                osd_uuid = teuthology.get_file(
+                osd_uuid = six.ensure_str(teuthology.get_file(
                     remote=remote,
                     path=datadir + '/fsid',
                     sudo=True,
-                ).strip()
+                )).strip()
                 osd_uuids[id_] = osd_uuid
     for osd_id in range(len(osd_uuids)):
         id_ = str(osd_id)
@@ -1513,16 +1493,9 @@ def wait_for_mon_quorum(ctx, config):
     with contextutil.safe_while(sleep=10, tries=60,
                                 action='wait for monitor quorum') as proceed:
         while proceed():
-            r = remote.run(
-                args=[
-                    'sudo',
-                    'ceph',
-                    'quorum_status',
-                ],
-                stdout=StringIO(),
-                logger=log.getChild('quorum_status'),
-            )
-            j = json.loads(r.stdout.getvalue())
+            quorum_status = remote.sh('sudo ceph quorum_status',
+                                      logger=log.getChild('quorum_status'))
+            j = json.loads(quorum_status)
             q = j.get('quorum_names', [])
             log.debug('Quorum: %s', q)
             if sorted(q) == sorted(mons):

--- a/qa/tasks/ceph_fuse.py
+++ b/qa/tasks/ceph_fuse.py
@@ -6,7 +6,7 @@ import contextlib
 import logging
 
 from teuthology import misc as teuthology
-from cephfs.fuse_mount import FuseMount
+from tasks.cephfs.fuse_mount import FuseMount
 
 log = logging.getLogger(__name__)
 

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -17,8 +17,8 @@ import os
 from io import BytesIO
 from teuthology import misc as teuthology
 from tasks.scrub import Scrubber
-from util.rados import cmd_erasure_code_profile
-from util import get_remote
+from tasks.util.rados import cmd_erasure_code_profile
+from tasks.util import get_remote
 from teuthology.contextutil import safe_while
 from teuthology.orchestra.remote import Remote
 from teuthology.orchestra import run

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -302,7 +302,7 @@ class OSDThrasher(Thrasher):
                                         "exp list-pgs failure with status {ret}".
                                         format(ret=proc.exitstatus))
 
-            pgs = proc.stdout.getvalue().split('\n')[:-1]
+            pgs = six.ensure_str(proc.stdout.getvalue()).split('\n')[:-1]
             if len(pgs) == 0:
                 self.log("No PGs found for osd.{osd}".format(osd=exp_osd))
                 return

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -1,7 +1,6 @@
 """
 ceph manager -- Thrasher and CephManager objects
 """
-from cStringIO import StringIO
 from functools import wraps
 import contextlib
 import random
@@ -14,6 +13,8 @@ import logging
 import threading
 import traceback
 import os
+
+from io import BytesIO
 from teuthology import misc as teuthology
 from tasks.scrub import Scrubber
 from util.rados import cmd_erasure_code_profile
@@ -57,7 +58,7 @@ def shell(ctx, cluster_name, remote, args, name=None, **kwargs):
     )
 
 def write_conf(ctx, conf_path=DEFAULT_CONF_PATH, cluster='ceph'):
-    conf_fp = StringIO()
+    conf_fp = BytesIO()
     ctx.ceph[cluster].conf.write(conf_fp)
     conf_fp.seek(0)
     writes = ctx.cluster.run(
@@ -212,8 +213,8 @@ class OSDThrasher(Thrasher):
         allremotes = list(set(allremotes))
         for remote in allremotes:
             proc = remote.run(args=['type', cmd], wait=True,
-                              check_status=False, stdout=StringIO(),
-                              stderr=StringIO())
+                              check_status=False, stdout=BytesIO(),
+                              stderr=BytesIO())
             if proc.exitstatus != 0:
                 return False;
         return True;
@@ -225,13 +226,13 @@ class OSDThrasher(Thrasher):
                 args=['ceph-objectstore-tool'] + cmd,
                 name=osd,
                 wait=True, check_status=False,
-                stdout=StringIO(),
-                stderr=StringIO())
+                stdout=BytesIO(),
+                stderr=BytesIO())
         else:
             return remote.run(
                 args=['sudo', 'adjust-ulimits', 'ceph-objectstore-tool'] + cmd,
-                wait=True, check_status=False, stdout=StringIO(),
-                stderr=StringIO())
+                wait=True, check_status=False, stdout=BytesIO(),
+                stderr=BytesIO())
 
     def kill_osd(self, osd=None, mark_down=False, mark_out=False):
         """
@@ -275,8 +276,8 @@ class OSDThrasher(Thrasher):
                 with safe_while(sleep=15, tries=40, action="type ceph-objectstore-tool") as proceed:
                     while proceed():
                         proc = exp_remote.run(args=['type', 'ceph-objectstore-tool'],
-                                              wait=True, check_status=False, stdout=StringIO(),
-                                              stderr=StringIO())
+                                              wait=True, check_status=False, stdout=BytesIO(),
+                                              stderr=BytesIO())
                         if proc.exitstatus == 0:
                             break
                         log.debug("ceph-objectstore-tool binary not present, trying again")
@@ -366,7 +367,7 @@ class OSDThrasher(Thrasher):
                     raise Exception("ceph-objectstore-tool: "
                                     "imp list-pgs failure with status {ret}".
                                     format(ret=proc.exitstatus))
-                pgs = proc.stdout.getvalue().split('\n')[:-1]
+                pgs = six.ensure_str(proc.stdout.getvalue()).split('\n')[:-1]
                 if pg not in pgs:
                     self.log("Moving pg {pg} from osd.{fosd} to osd.{tosd}".
                              format(pg=pg, fosd=exp_osd, tosd=imp_osd))
@@ -441,8 +442,7 @@ class OSDThrasher(Thrasher):
                                '--journal-path', JPATH.format(id=imp_osd),
                            ])
                            + " --op apply-layout-settings --pool " + pool).format(id=osd)
-                    proc = imp_remote.run(args=cmd, wait=True, check_status=False, stderr=StringIO())
-                    output = proc.stderr.getvalue()
+                    output = imp_remote.sh(args=cmd, wait=True, check_status=False)
                     if 'Couldn\'t find pool' in output:
                         continue
                     if proc.exitstatus:
@@ -1266,7 +1266,7 @@ class ObjectStoreTool:
 
     def run(self, options, args, stdin=None, stdout=None):
         if stdout is None:
-            stdout = StringIO()
+            stdout = BytesIO()
         self.manager.kill_osd(self.osd)
         cmd = self.build_cmd(options, args, stdin)
         self.manager.log(cmd)
@@ -1274,11 +1274,12 @@ class ObjectStoreTool:
             proc = self.remote.run(args=['bash', '-e', '-x', '-c', cmd],
                                    check_status=False,
                                    stdout=stdout,
-                                   stderr=StringIO())
+                                   stderr=BytesIO())
             proc.wait()
             if proc.exitstatus != 0:
                 self.manager.log("failed with " + str(proc.exitstatus))
-                error = proc.stdout.getvalue() + " " + proc.stderr.getvalue()
+                error = six.ensure_str(proc.stdout.getvalue())  + " " + \
+                        six.ensure_str(proc.stderr.getvalue())
                 raise Exception(error)
         finally:
             if self.do_revive:
@@ -1337,7 +1338,7 @@ class CephManager:
         if self.cephadm:
             proc = shell(self.ctx, self.cluster, self.controller,
                          args=['ceph'] + list(args),
-                         stdout=StringIO())
+                         stdout=BytesIO())
         else:
             testdir = teuthology.get_testdir(self.ctx)
             ceph_args = [
@@ -1355,9 +1356,9 @@ class CephManager:
             ceph_args.extend(args)
             proc = self.controller.run(
                 args=ceph_args,
-                stdout=StringIO(),
+                stdout=BytesIO(),
             )
-        return proc.stdout.getvalue()
+        return six.ensure_str(proc.stdout.getvalue())
 
     def raw_cluster_cmd_result(self, *args, **kwargs):
         """
@@ -1388,7 +1389,7 @@ class CephManager:
 
     def run_ceph_w(self, watch_channel=None):
         """
-        Execute "ceph -w" in the background with stdout connected to a StringIO,
+        Execute "ceph -w" in the background with stdout connected to a BytesIO,
         and return the RemoteProcess.
 
         :param watch_channel: Specifies the channel to be watched. This can be
@@ -1405,7 +1406,7 @@ class CephManager:
         if watch_channel is not None:
             args.append("--watch-channel")
             args.append(watch_channel)
-        return self.controller.run(args=args, wait=False, stdout=StringIO(), stdin=run.PIPE)
+        return self.controller.run(args=args, wait=False, stdout=BytesIO(), stdin=run.PIPE)
 
     def get_mon_socks(self):
         """
@@ -1588,7 +1589,7 @@ class CephManager:
 
     def osd_admin_socket(self, osd_id, command, check_status=True, timeout=0, stdout=None):
         if stdout is None:
-            stdout = StringIO()
+            stdout = BytesIO()
         return self.admin_socket('osd', osd_id, command, check_status, timeout, stdout)
 
     def find_remote(self, service_type, service_id):
@@ -1612,7 +1613,7 @@ class CephManager:
                         to the admin socket
         """
         if stdout is None:
-            stdout = StringIO()
+            stdout =BytesIO()
 
         remote = self.find_remote(service_type, service_id)
 
@@ -1741,7 +1742,7 @@ class CephManager:
         five seconds and try again.
         """
         if stdout is None:
-            stdout = StringIO()
+            stdout = BytesIO()
         tries = 0
         while True:
             proc = self.admin_socket(service_type, service_id,

--- a/qa/tasks/ceph_objectstore_tool.py
+++ b/qa/tasks/ceph_objectstore_tool.py
@@ -1,18 +1,21 @@
 """
 ceph_objectstore_tool - Simple test of ceph-objectstore-tool utility
 """
-from cStringIO import StringIO
 import contextlib
 import logging
 import ceph_manager
 from teuthology import misc as teuthology
 import time
 import os
+import six
 import string
 from teuthology.orchestra import run
 import sys
 import tempfile
 import json
+
+from teuthology.exceptions import CommandFailedError
+
 from util.rados import (rados, create_replicated_pool, create_ec_pool)
 # from util.rados import (rados, create_ec_pool,
 #                               create_replicated_pool,
@@ -289,14 +292,9 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
             log.info("process osd.{id} on {remote}".
                      format(id=osdid, remote=remote))
             cmd = (prefix + "--op list").format(id=osdid)
-            proc = remote.run(args=cmd.split(), check_status=False,
-                              stdout=StringIO())
-            if proc.exitstatus != 0:
-                log.error("Bad exit status {ret} from --op list request".
-                          format(ret=proc.exitstatus))
-                ERRORS += 1
-            else:
-                for pgline in proc.stdout.getvalue().splitlines():
+            try:
+                lines = remote.sh(cmd, check_status=False).splitlines()
+                for pgline in lines:
                     if not pgline:
                         continue
                     (pg, obj) = json.loads(pgline)
@@ -306,6 +304,10 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
                         objsinpg.setdefault(pg, []).append(name)
                         db[name].setdefault("pg2json",
                                             {})[pg] = json.dumps(obj)
+            except CommandFailedError as e:
+                log.error("Bad exit status {ret} from --op list request".
+                          format(ret=e.exitstatus))
+                ERRORS += 1
 
     log.info(db)
     log.info(pgswithobjects)
@@ -376,20 +378,18 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
                                    format(id=osdid, pg=pg).split())
                             cmd.append(run.Raw("'{json}'".format(json=JSON)))
                             cmd += "get-bytes -".split()
-                            proc = remote.run(args=cmd, check_status=False,
-                                              stdout=StringIO())
-                            proc.wait()
-                            if proc.exitstatus != 0:
-                                log.error("get-bytes after "
-                                          "set-bytes ret={ret}".
-                                          format(ret=proc.exitstatus))
-                                ERRORS += 1
-                            else:
-                                if data != proc.stdout.getvalue():
+                            try:
+                                output = remote.sh(cmd, wait=True)
+                                if data != output:
                                     log.error("Data inconsistent after "
                                               "set-bytes, got:")
-                                    log.error(proc.stdout.getvalue())
+                                    log.error(output)
                                     ERRORS += 1
+                            except CommandFailedError as e:
+                                log.error("get-bytes after "
+                                          "set-bytes ret={ret}".
+                                          format(ret=e.exitstatus))
+                                ERRORS += 1
 
                             cmd = ((prefix + "--pgid {pg}").
                                    format(id=osdid, pg=pg).split())
@@ -425,15 +425,13 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
                                format(id=osdid, pg=pg).split())
                         cmd.append(run.Raw("'{json}'".format(json=JSON)))
                         cmd += ["list-attrs"]
-                        proc = remote.run(args=cmd, check_status=False,
-                                          stdout=StringIO(), stderr=StringIO())
-                        proc.wait()
-                        if proc.exitstatus != 0:
+                        try:
+                            keys = remote.sh(cmd, wait=True, stderr=BytesIO()).split()
+                        except CommandFailedError as e:
                             log.error("Bad exit status {ret}".
-                                      format(ret=proc.exitstatus))
+                                      format(ret=e.exitstatus))
                             ERRORS += 1
                             continue
-                        keys = proc.stdout.getvalue().split()
                         values = dict(db[basename]["xattr"])
 
                         for key in keys:
@@ -453,15 +451,13 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
                             cmd.append(run.Raw("'{json}'".format(json=JSON)))
                             cmd += ("get-attr {key}".
                                     format(key="_" + key).split())
-                            proc = remote.run(args=cmd, check_status=False,
-                                              stdout=StringIO())
-                            proc.wait()
-                            if proc.exitstatus != 0:
+                            try:
+                                val = remote.sh(cmd, wait=True)
+                            except CommandFailedError as e:
                                 log.error("get-attr failed with {ret}".
-                                          format(ret=proc.exitstatus))
+                                          format(ret=e.exitstatus))
                                 ERRORS += 1
                                 continue
-                            val = proc.stdout.getvalue()
                             if exp != val:
                                 log.error("For key {key} got value {got} "
                                           "instead of {expected}".
@@ -483,14 +479,16 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
                             proc = remote.run(args=['bash', '-e', '-x',
                                                     '-c', cmd],
                                               check_status=False,
-                                              stdout=StringIO(),
-                                              stderr=StringIO())
+                                              stdout=BytesIO(),
+                                              stderr=BytesIO())
                             proc.wait()
                             if proc.exitstatus != 0:
                                 log.error("failed with " +
                                           str(proc.exitstatus))
-                                log.error(proc.stdout.getvalue() + " " +
-                                          proc.stderr.getvalue())
+                                log.error(" ".join([
+                                    six.ensure_str(proc.stdout.getvalue()),
+                                    six.ensure_str(proc.stderr.getvalue()),
+                                    ]))
                                 ERRORS += 1
 
                         if len(values) != 0:
@@ -509,15 +507,13 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
             for pg in pgs[osdid]:
                 cmd = ((prefix + "--op info --pgid {pg}").
                        format(id=osdid, pg=pg).split())
-                proc = remote.run(args=cmd, check_status=False,
-                                  stdout=StringIO())
-                proc.wait()
-                if proc.exitstatus != 0:
+                try:
+                    info = remote.sh(cmd, wait=True)
+                except CommandFailedError as e:
                     log.error("Failure of --op info command with {ret}".
-                              format(proc.exitstatus))
+                              format(e.exitstatus))
                     ERRORS += 1
                     continue
-                info = proc.stdout.getvalue()
                 if not str(pg) in info:
                     log.error("Bad data from info: {info}".format(info=info))
                     ERRORS += 1
@@ -534,17 +530,16 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
             for pg in pgs[osdid]:
                 cmd = ((prefix + "--op log --pgid {pg}").
                        format(id=osdid, pg=pg).split())
-                proc = remote.run(args=cmd, check_status=False,
-                                  stdout=StringIO())
-                proc.wait()
-                if proc.exitstatus != 0:
+                try:
+                    output = remote.sh(cmd, wait=True)
+                except CommandFailedError as e:
                     log.error("Getting log failed for pg {pg} "
                               "from osd.{id} with {ret}".
-                              format(pg=pg, id=osdid, ret=proc.exitstatus))
+                              format(pg=pg, id=osdid, ret=e.exitstatus))
                     ERRORS += 1
                     continue
                 HASOBJ = pg in pgswithobjects
-                MODOBJ = "modify" in proc.stdout.getvalue()
+                MODOBJ = "modify" in output
                 if HASOBJ != MODOBJ:
                     log.error("Bad log for pg {pg} from osd.{id}".
                               format(pg=pg, id=osdid))
@@ -569,13 +564,12 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
 
                 cmd = ((prefix + "--op export --pgid {pg} --file {file}").
                        format(id=osdid, pg=pg, file=fpath))
-                proc = remote.run(args=cmd, check_status=False,
-                                  stdout=StringIO())
-                proc.wait()
-                if proc.exitstatus != 0:
+                try:
+                    remote.sh(cmd, wait=True)
+                except CommandFailedError as e:
                     log.error("Exporting failed for pg {pg} "
                               "on osd.{id} with {ret}".
-                              format(pg=pg, id=osdid, ret=proc.exitstatus))
+                              format(pg=pg, id=osdid, ret=e.exitstatus))
                     EXP_ERRORS += 1
 
     ERRORS += EXP_ERRORS
@@ -593,13 +587,12 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
             for pg in pgs[osdid]:
                 cmd = ((prefix + "--force --op remove --pgid {pg}").
                        format(pg=pg, id=osdid))
-                proc = remote.run(args=cmd, check_status=False,
-                                  stdout=StringIO())
-                proc.wait()
-                if proc.exitstatus != 0:
+                try:
+                    remote.sh(cmd, wait=True)
+                except CommandFailedError as e:
                     log.error("Removing failed for pg {pg} "
                               "on osd.{id} with {ret}".
-                              format(pg=pg, id=osdid, ret=proc.exitstatus))
+                              format(pg=pg, id=osdid, ret=e.exitstatus))
                     RM_ERRORS += 1
 
     ERRORS += RM_ERRORS
@@ -622,12 +615,11 @@ def test_objectstore(ctx, config, cli_remote, REP_POOL, REP_NAME, ec=False):
 
                     cmd = ((prefix + "--op import --file {file}").
                            format(id=osdid, file=fpath))
-                    proc = remote.run(args=cmd, check_status=False,
-                                      stdout=StringIO())
-                    proc.wait()
-                    if proc.exitstatus != 0:
+                    try:
+                        remote.sh(cmd, wait=True)
+                    except CommandFailedError as e:
                         log.error("Import failed from {file} with {ret}".
-                                  format(file=fpath, ret=proc.exitstatus))
+                                  format(file=fpath, ret=e.exitstatus))
                         IMP_ERRORS += 1
     else:
         log.warning("SKIPPING IMPORT TESTS DUE TO PREVIOUS FAILURES")

--- a/qa/tasks/ceph_objectstore_tool.py
+++ b/qa/tasks/ceph_objectstore_tool.py
@@ -1,6 +1,7 @@
 """
 ceph_objectstore_tool - Simple test of ceph-objectstore-tool utility
 """
+from io import BytesIO
 import contextlib
 import logging
 import ceph_manager

--- a/qa/tasks/cephadm.py
+++ b/qa/tasks/cephadm.py
@@ -1,7 +1,7 @@
 """
 Ceph cluster task, deployed via cephadm orchestrator
 """
-from cStringIO import StringIO
+from io import BytesIO
 
 import argparse
 import configobj
@@ -189,7 +189,7 @@ def ceph_log(ctx, config):
                 run.Raw('|'), 'head', '-n', '1',
             ])
             r = ctx.ceph[cluster_name].bootstrap_remote.run(
-                stdout=StringIO(),
+                stdout=BytesIO(),
                 args=args,
             )
             stdout = r.stdout.getvalue()
@@ -313,7 +313,7 @@ def ceph_bootstrap(ctx, config):
     try:
         # write seed config
         log.info('Writing seed config...')
-        conf_fp = StringIO()
+        conf_fp = BytesIO()
         seed_config = build_initial_config(ctx, config)
         seed_config.write(conf_fp)
         teuthology.write_file(
@@ -423,7 +423,7 @@ def ceph_bootstrap(ctx, config):
             ])
             r = _shell(ctx, cluster_name, remote,
                        ['ceph', 'orch', 'host', 'ls', '--format=json'],
-                       stdout=StringIO())
+                       stdout=BytesIO())
             hosts = [node['hostname'] for node in json.loads(r.stdout.getvalue())]
             assert remote.shortname in hosts
 
@@ -490,7 +490,7 @@ def ceph_mons(ctx, config):
                             args=[
                                 'ceph', 'mon', 'dump', '-f', 'json',
                             ],
-                            stdout=StringIO(),
+                            stdout=BytesIO(),
                         )
                         j = json.loads(r.stdout.getvalue())
                         if len(j['mons']) == num_mons:
@@ -748,7 +748,7 @@ def ceph_clients(ctx, config):
                     'mds', 'allow *',
                     'mgr', 'allow *',
                 ],
-                stdout=StringIO(),
+                stdout=BytesIO(),
             )
             keyring = r.stdout.getvalue()
             teuthology.sudo_write_file(

--- a/qa/tasks/cephfs/fuse_mount.py
+++ b/qa/tasks/cephfs/fuse_mount.py
@@ -1,14 +1,17 @@
-from StringIO import StringIO
+from io import BytesIO
 import json
 import time
 import logging
+
+import six
+
 from textwrap import dedent
 
 from teuthology import misc
 from teuthology.contextutil import MaxWhileTries
 from teuthology.orchestra import run
 from teuthology.orchestra.run import CommandFailedError
-from .mount import CephFSMount
+from tasks.cephfs.mount import CephFSMount
 
 log = logging.getLogger(__name__)
 
@@ -92,16 +95,12 @@ class FuseMount(CephFSMount):
                 check_status=False,
                 timeout=(15*60)
             )
-            p = self.client_remote.run(
-                args=["ls", "/sys/fs/fuse/connections"],
-                stdout=StringIO(),
-                check_status=False,
-                timeout=(15*60)
-            )
-            if p.exitstatus != 0:
+            try:
+                ls_str = self.client_remote.sh("ls /sys/fs/fuse/connections",
+                                               timeout=(15*60)).strip()
+            except CommandFailedError:
                 return []
 
-            ls_str = p.stdout.getvalue().strip()
             if ls_str:
                 return [int(n) for n in ls_str.split("\n")]
             else:
@@ -182,16 +181,17 @@ class FuseMount(CephFSMount):
                 '--',
                 self.mountpoint,
             ],
-            stdout=StringIO(),
-            stderr=StringIO(),
+            stdout=BytesIO(),
+            stderr=BytesIO(),
             wait=False,
             timeout=(15*60)
         )
         try:
             proc.wait()
         except CommandFailedError:
-            if ("endpoint is not connected" in proc.stderr.getvalue()
-            or "Software caused connection abort" in proc.stderr.getvalue()):
+            error = six.ensure_str(proc.stderr.getvalue())
+            if ("endpoint is not connected" in error
+            or "Software caused connection abort" in error):
                 # This happens is fuse is killed without unmount
                 log.warn("Found stale moutn point at {0}".format(self.mountpoint))
                 return True
@@ -200,7 +200,7 @@ class FuseMount(CephFSMount):
                 log.info('mount point does not exist: %s', self.mountpoint)
                 return False
 
-        fstype = proc.stdout.getvalue().rstrip('\n')
+        fstype = six.ensure_str(proc.stdout.getvalue()).rstrip('\n')
         if fstype == 'fuseblk':
             log.info('ceph-fuse is mounted on %s', self.mountpoint)
             return True
@@ -225,11 +225,11 @@ class FuseMount(CephFSMount):
         # Now that we're mounted, set permissions so that the rest of the test will have
         # unrestricted access to the filesystem mount.
         try:
-            stderr = StringIO()
+            stderr = BytesIO()
             self.client_remote.run(args=['sudo', 'chmod', '1777', self.mountpoint], timeout=(15*60), stderr=stderr)
         except run.CommandFailedError:
             stderr = stderr.getvalue()
-            if "Read-only file system".lower() in stderr.lower():
+            if b"Read-only file system".lower() in stderr.lower():
                 pass
             else:
                 raise
@@ -271,7 +271,7 @@ class FuseMount(CephFSMount):
                 """).format(self._fuse_conn))
                 self._fuse_conn = None
 
-            stderr = StringIO()
+            stderr = BytesIO()
             try:
                 # make sure its unmounted
                 self.client_remote.run(
@@ -338,7 +338,7 @@ class FuseMount(CephFSMount):
 
         Prerequisite: the client is not mounted.
         """
-        stderr = StringIO()
+        stderr = BytesIO()
         try:
             self.client_remote.run(
                 args=[
@@ -351,7 +351,7 @@ class FuseMount(CephFSMount):
                 check_status=False,
             )
         except CommandFailedError:
-            if "No such file or directory" in stderr.getvalue():
+            if b"No such file or directory" in stderr.getvalue():
                 pass
             else:
                 raise
@@ -435,17 +435,16 @@ print(find_socket("{client_name}"))
             client_name="client.{0}".format(self.client_id))
 
         # Find the admin socket
-        p = self.client_remote.run(args=[
+        asok_path = self.client_remote.sh([
             'sudo', 'python3', '-c', pyscript
-        ], stdout=StringIO(), timeout=(15*60))
-        asok_path = p.stdout.getvalue().strip()
+        ], timeout=(15*60)).strip()
         log.info("Found client admin socket at {0}".format(asok_path))
 
         # Query client ID from admin socket
-        p = self.client_remote.run(
-            args=['sudo', self._prefix + 'ceph', '--admin-daemon', asok_path] + args,
-            stdout=StringIO(), timeout=(15*60))
-        return json.loads(p.stdout.getvalue())
+        json_data = self.client_remote.sh(
+            ['sudo', self._prefix + 'ceph', '--admin-daemon', asok_path] + args,
+            timeout=(15*60))
+        return json.loads(json_data)
 
     def get_global_id(self):
         """

--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -1,4 +1,3 @@
-from StringIO import StringIO
 import json
 import logging
 import time
@@ -208,10 +207,10 @@ class KernelMount(CephFSMount):
             print(json.dumps(get_id_to_dir()))
             """)
 
-        p = self.client_remote.run(args=[
+        output = self.client_remote.sh([
             'sudo', 'python3', '-c', pyscript
-        ], stdout=StringIO(), timeout=(5*60))
-        client_id_to_dir = json.loads(p.stdout.getvalue())
+        ], timeout=(5*60))
+        client_id_to_dir = json.loads(output)
 
         try:
             return client_id_to_dir[self.client_id]
@@ -230,10 +229,10 @@ class KernelMount(CephFSMount):
             print(open(os.path.join("{debug_dir}", "{filename}")).read())
             """).format(debug_dir=debug_dir, filename=filename)
 
-        p = self.client_remote.run(args=[
+        output = self.client_remote.sh([
             'sudo', 'python3', '-c', pyscript
-        ], stdout=StringIO(), timeout=(5*60))
-        return p.stdout.getvalue()
+        ], timeout=(5*60))
+        return output
 
     def get_global_id(self):
         """

--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -2,10 +2,10 @@ from contextlib import contextmanager
 import json
 import logging
 import datetime
+import six
 import time
 from textwrap import dedent
 import os
-from StringIO import StringIO
 from teuthology.orchestra import run
 from teuthology.orchestra.run import CommandFailedError, ConnectionLostError
 from tasks.cephfs.filesystem import Filesystem
@@ -184,12 +184,12 @@ class CephFSMount(object):
         return self.client_remote.run(
                args=['sudo', 'adjust-ulimits', 'daemon-helper', 'kill',
                      py_version, '-c', pyscript], wait=False, stdin=run.PIPE,
-               stdout=StringIO())
+               stdout=BytesIO())
 
     def run_python(self, pyscript, py_version='python3'):
         p = self._run_python(pyscript, py_version)
         p.wait()
-        return p.stdout.getvalue().strip()
+        return six.ensure_str(p.stdout.getvalue().strip())
 
     def run_shell(self, args, wait=True, stdin=None, check_status=True,
                   omit_sudo=True):
@@ -197,8 +197,8 @@ class CephFSMount(object):
             args = args.split()
 
         args = ["cd", self.mountpoint, run.Raw('&&'), "sudo"] + args
-        return self.client_remote.run(args=args, stdout=StringIO(),
-                                      stderr=StringIO(), wait=wait,
+        return self.client_remote.run(args=args, stdout=BytesIO(),
+                                      stderr=BytesIO(), wait=wait,
                                       stdin=stdin, check_status=check_status,
                                       omit_sudo=omit_sudo)
 

--- a/qa/tasks/daemonwatchdog.py
+++ b/qa/tasks/daemonwatchdog.py
@@ -99,7 +99,7 @@ class DaemonWatchdog(Greenlet):
                     bark = True
 
             # If a daemon is no longer failed, remove it from tracking:
-            for name in daemon_failure_time.keys():
+            for name in list(daemon_failure_time.keys()):
                 if name not in [d.role + '.' + d.id_ for d in daemon_failures]:
                     self.log("daemon {name} has been restored".format(name=name))
                     del daemon_failure_time[name]

--- a/qa/tasks/devstack.py
+++ b/qa/tasks/devstack.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import contextlib
 import logging
-from cStringIO import StringIO
+from io import BytesIO
 import textwrap
 from configparser import ConfigParser
 import time
@@ -140,7 +140,7 @@ def distribute_ceph_keys(devstack_node, ceph_node):
     log.info("Copying Ceph keys to DevStack node...")
 
     def copy_key(from_remote, key_name, to_remote, dest_path, owner):
-        key_stringio = StringIO()
+        key_stringio = BytesIO()
         from_remote.run(
             args=['sudo', 'ceph', 'auth', 'get-or-create', key_name],
             stdout=key_stringio)
@@ -172,14 +172,8 @@ def distribute_ceph_keys(devstack_node, ceph_node):
 def set_libvirt_secret(devstack_node, ceph_node):
     log.info("Setting libvirt secret...")
 
-    cinder_key_stringio = StringIO()
-    ceph_node.run(args=['sudo', 'ceph', 'auth', 'get-key', 'client.cinder'],
-                  stdout=cinder_key_stringio)
-    cinder_key = cinder_key_stringio.getvalue().strip()
-
-    uuid_stringio = StringIO()
-    devstack_node.run(args=['uuidgen'], stdout=uuid_stringio)
-    uuid = uuid_stringio.getvalue().strip()
+    cinder_key = ceph_node.sh('sudo ceph auth get-key client.cinder').strip()
+    uuid = devstack_node.sh('uuidgen').strip()
 
     secret_path = '/tmp/secret.xml'
     secret_template = textwrap.dedent("""

--- a/qa/tasks/kclient.py
+++ b/qa/tasks/kclient.py
@@ -8,7 +8,7 @@ from teuthology.misc import deep_merge
 from teuthology.orchestra.run import CommandFailedError
 from teuthology import misc
 from teuthology.contextutil import MaxWhileTries
-from cephfs.kernel_mount import KernelMount
+from tasks.cephfs.kernel_mount import KernelMount
 
 log = logging.getLogger(__name__)
 

--- a/qa/tasks/manypools.py
+++ b/qa/tasks/manypools.py
@@ -68,6 +68,6 @@ def task(ctx, config):
             log.info('waiting for pool and object creates')
             poolprocs[remote] = proc
 
-        run.wait(poolprocs.itervalues())
+        run.wait(poolprocs.values())
 
     log.info('created all {n} pools and wrote 16 objects to each'.format(n=poolnum))

--- a/qa/tasks/mgr/test_crash.py
+++ b/qa/tasks/mgr/test_crash.py
@@ -1,6 +1,6 @@
 
 
-from mgr_test_case import MgrTestCase
+from tasks.mgr.mgr_test_case import MgrTestCase
 
 import json
 import logging

--- a/qa/tasks/mgr/test_crash.py
+++ b/qa/tasks/mgr/test_crash.py
@@ -46,13 +46,13 @@ class TestCrash(MgrTestCase):
         self.oldest_crashid = crash_id
 
     def tearDown(self):
-        for crash in self.crashes.itervalues():
+        for crash in self.crashes.values():
             self.mgr_cluster.mon_manager.raw_cluster_cmd_result(
                 'crash', 'rm', crash['crash_id']
             )
 
     def test_info(self):
-        for crash in self.crashes.itervalues():
+        for crash in self.crashes.values():
             log.warning('test_info: crash %s' % crash)
             retstr = self.mgr_cluster.mon_manager.raw_cluster_cmd(
                 'crash', 'ls'
@@ -70,7 +70,7 @@ class TestCrash(MgrTestCase):
         retstr = self.mgr_cluster.mon_manager.raw_cluster_cmd(
             'crash', 'ls',
         )
-        for crash in self.crashes.itervalues():
+        for crash in self.crashes.values():
             self.assertIn(crash['crash_id'], retstr)
 
     def test_rm(self):

--- a/qa/tasks/mon_thrash.py
+++ b/qa/tasks/mon_thrash.py
@@ -3,13 +3,13 @@ Monitor thrash
 """
 import logging
 import contextlib
-import ceph_manager
 import random
 import time
 import gevent
 import json
 import math
 from teuthology import misc as teuthology
+from tasks import ceph_manager
 from tasks.cephfs.filesystem import MDSCluster
 from tasks.thrasher import Thrasher
 

--- a/qa/tasks/netem.py
+++ b/qa/tasks/netem.py
@@ -6,7 +6,6 @@ Reference:https://wiki.linuxfoundation.org/networking/netem.
 
 import logging
 import contextlib
-from cStringIO import StringIO
 from paramiko import SSHException
 import socket
 import time
@@ -59,8 +58,8 @@ def static_delay(remote, host, interface, delay):
 
     ip = socket.gethostbyname(host.hostname)
 
-    r = remote.run(args=show_tc(interface), stdout=StringIO())
-    if r.stdout.getvalue().strip().find('refcnt') == -1:
+    tc = remote.sh(show_tc(interface))
+    if tc.strip().find('refcnt') == -1:
         # call set_priority() func to create priority queue
         # if not already created(indicated by -1)
         log.info('Create priority queue')
@@ -94,8 +93,8 @@ def variable_delay(remote, host, interface, delay_range=[]):
     delay1 = delay_range[0]
     delay2 = delay_range[1]
 
-    r = remote.run(args=show_tc(interface), stdout=StringIO())
-    if r.stdout.getvalue().strip().find('refcnt') == -1:
+    tc = remote.sh(show_tc(interface))
+    if tc.strip().find('refcnt') == -1:
         # call set_priority() func to create priority queue
         # if not already created(indicated by -1)
         remote.run(args=set_priority(interface))
@@ -121,8 +120,8 @@ def delete_dev(remote, interface):
     """ Delete the qdisc if present"""
 
     log.info('Delete tc')
-    r = remote.run(args=show_tc(interface), stdout=StringIO())
-    if r.stdout.getvalue().strip().find('refcnt') != -1:
+    tc = remote.sh(show_tc(interface))
+    if tc.strip().find('refcnt') != -1:
         remote.run(args=del_tc(interface))
 
 
@@ -144,8 +143,8 @@ class Toggle:
 
         _, _, set_ip = cmd_prefix(self.interface)
 
-        r = self.remote.run(args=show_tc(self.interface), stdout=StringIO())
-        if r.stdout.getvalue().strip().find('refcnt') == -1:
+        tc = self.remote.sh(show_tc(self.interface))
+        if tc.strip().find('refcnt') == -1:
             self.remote.run(args=set_priority(self.interface))
             # packet drop to specific ip
             log.info('Drop all packets to %s' % self.host)

--- a/qa/tasks/omapbench.py
+++ b/qa/tasks/omapbench.py
@@ -82,4 +82,4 @@ def task(ctx, config):
         yield
     finally:
         log.info('joining omapbench')
-        run.wait(omapbench.itervalues())
+        run.wait(omapbench.values())

--- a/qa/tasks/osd_failsafe_enospc.py
+++ b/qa/tasks/osd_failsafe_enospc.py
@@ -1,8 +1,9 @@
 """
 Handle osdfailsafe configuration settings (nearfull ratio and full ratio)
 """
-from cStringIO import StringIO
+from io import BytesIO
 import logging
+import six
 import time
 
 from teuthology.orchestra import run
@@ -64,7 +65,7 @@ def task(ctx, config):
                  'ceph', '-w'
              ],
              stdin=run.PIPE,
-             stdout=StringIO(),
+             stdout=BytesIO(),
              wait=False,
         )
 
@@ -74,7 +75,7 @@ def task(ctx, config):
     proc.stdin.close() # causes daemon-helper send SIGKILL to ceph -w
     proc.wait()
 
-    lines = proc.stdout.getvalue().split('\n')
+    lines = six.ensure_str(proc.stdout.getvalue()).split('\n')
 
     count = len(filter(lambda line: '[WRN] OSD near full' in line, lines))
     assert count == 2, 'Incorrect number of warning messages expected 2 got %d' % count
@@ -92,7 +93,7 @@ def task(ctx, config):
                  'ceph', '-w'
              ],
              stdin=run.PIPE,
-             stdout=StringIO(),
+             stdout=BytesIO(),
              wait=False,
         )
 
@@ -102,7 +103,7 @@ def task(ctx, config):
     proc.stdin.close() # causes daemon-helper send SIGKILL to ceph -w
     proc.wait()
 
-    lines = proc.stdout.getvalue().split('\n')
+    lines = six.ensure_str(proc.stdout.getvalue()).split('\n')
 
     count = len(filter(lambda line: '[ERR] OSD full dropping all updates' in line, lines))
     assert count == 2, 'Incorrect number of error messages expected 2 got %d' % count
@@ -134,7 +135,7 @@ def task(ctx, config):
                  'ceph', '-w'
              ],
              stdin=run.PIPE,
-             stdout=StringIO(),
+             stdout=BytesIO(),
              wait=False,
         )
 
@@ -142,7 +143,7 @@ def task(ctx, config):
     proc.stdin.close() # causes daemon-helper send SIGKILL to ceph -w
     proc.wait()
 
-    lines = proc.stdout.getvalue().split('\n')
+    lines = six.ensure_str(proc.stdout.getvalue()).split('\n')
 
     count = len(filter(lambda line: '[WRN] OSD near full' in line, lines))
     assert count == 1 or count == 2, 'Incorrect number of warning messages expected 1 or 2 got %d' % count
@@ -163,7 +164,7 @@ def task(ctx, config):
                  'ceph', '-w'
              ],
              stdin=run.PIPE,
-             stdout=StringIO(),
+             stdout=BytesIO(),
              wait=False,
         )
 
@@ -173,7 +174,7 @@ def task(ctx, config):
     proc.stdin.close() # causes daemon-helper send SIGKILL to ceph -w
     proc.wait()
 
-    lines = proc.stdout.getvalue().split('\n')
+    lines = six.ensure_str(proc.stdout.getvalue()).split('\n')
 
     count = len(filter(lambda line: '[WRN] OSD near full' in line, lines))
     assert count == 0, 'Incorrect number of warning messages expected 0 got %d' % count
@@ -194,7 +195,7 @@ def task(ctx, config):
                  'ceph', '-w'
              ],
              stdin=run.PIPE,
-             stdout=StringIO(),
+             stdout=BytesIO(),
              wait=False,
         )
 
@@ -202,7 +203,7 @@ def task(ctx, config):
     proc.stdin.close() # causes daemon-helper send SIGKILL to ceph -w
     proc.wait()
 
-    lines = proc.stdout.getvalue().split('\n')
+    lines = six.ensure_str(proc.stdout.getvalue()).split('\n')
 
     count = len(filter(lambda line: '[WRN] OSD near full' in line, lines))
     assert count == 0, 'Incorrect number of warning messages expected 0 got %d' % count

--- a/qa/tasks/osd_max_pg_per_osd.py
+++ b/qa/tasks/osd_max_pg_per_osd.py
@@ -6,12 +6,12 @@ log = logging.getLogger(__name__)
 
 
 def pg_num_in_all_states(pgs, *states):
-    return sum(1 for state in pgs.itervalues()
+    return sum(1 for state in pgs.values()
                if all(s in state for s in states))
 
 
 def pg_num_in_any_state(pgs, *states):
-    return sum(1 for state in pgs.itervalues()
+    return sum(1 for state in pgs.values()
                if any(s in state for s in states))
 
 

--- a/qa/tasks/qemu.py
+++ b/qa/tasks/qemu.py
@@ -1,7 +1,6 @@
 """
 Qemu task
 """
-from cStringIO import StringIO
 
 import contextlib
 import logging
@@ -172,7 +171,7 @@ def generate_iso(ctx, config):
         user_data = user_data.format(
             ceph_branch=ctx.config.get('branch'),
             ceph_sha1=ctx.config.get('sha1'))
-        teuthology.write_file(remote, userdata_path, StringIO(user_data))
+        teuthology.write_file(remote, userdata_path, user_data)
 
         with open(os.path.join(src_dir, 'metadata.yaml'), 'rb') as f:
             teuthology.write_file(remote, metadata_path, f)

--- a/qa/tasks/rados.py
+++ b/qa/tasks/rados.py
@@ -263,7 +263,7 @@ def task(ctx, config):
                     wait=False
                     )
                 tests[id_] = proc
-            run.wait(tests.itervalues())
+            run.wait(tests.values())
 
             for pool in created_pools:
                 manager.wait_snap_trimming_complete(pool);

--- a/qa/tasks/radosbench.py
+++ b/qa/tasks/radosbench.py
@@ -135,7 +135,7 @@ def task(ctx, config):
     finally:
         timeout = config.get('time', 360) * 30 + 300
         log.info('joining radosbench (timing out after %ss)', timeout)
-        run.wait(radosbench.itervalues(), timeout=timeout)
+        run.wait(radosbench.values(), timeout=timeout)
 
         if pool != 'data' and create_pool:
             manager.remove_pool(pool)

--- a/qa/tasks/radosbenchsweep.py
+++ b/qa/tasks/radosbenchsweep.py
@@ -5,7 +5,7 @@ import contextlib
 import logging
 import re
 
-from cStringIO import StringIO
+from io import BytesIO
 from itertools import product
 
 from teuthology.orchestra import run
@@ -189,7 +189,7 @@ def run_radosbench(ctx, config, f, num_osds, size, replica, rep):
             ],
             logger=log.getChild('radosbench.{id}'.format(id=id_)),
             stdin=run.PIPE,
-            stdout=StringIO(),
+            stdout=BytesIO(),
             wait=False
         )
 

--- a/qa/tasks/radosgw_admin.py
+++ b/qa/tasks/radosgw_admin.py
@@ -17,8 +17,9 @@ import datetime
 import Queue
 
 import sys
+import six
 
-from cStringIO import StringIO
+from io import BytesIO
 
 import boto.exception
 import boto.s3.connection
@@ -1038,7 +1039,7 @@ def task(ctx, config):
     out['placement_pools'].append(rule)
 
     (err, out) = rgwadmin(ctx, client, ['zone', 'set'],
-        stdin=StringIO(json.dumps(out)),
+        stdin=BytesIO(six.ensure_binary(json.dumps(out))),
         check_status=True)
 
     (err, out) = rgwadmin(ctx, client, ['zone', 'get'])

--- a/qa/tasks/radosgw_admin.py
+++ b/qa/tasks/radosgw_admin.py
@@ -1071,16 +1071,15 @@ def main():
     client0 = remote.Remote(user + host)
     ctx = config
     ctx.cluster=cluster.Cluster(remotes=[(client0,
-     [ 'ceph.client.rgw.%s' % (host),  ]),])
-
+        [ 'ceph.client.rgw.%s' % (host),  ]),])
     ctx.rgw = argparse.Namespace()
     endpoints = {}
     endpoints['ceph.client.rgw.%s' % host] = (host, 80)
     ctx.rgw.role_endpoints = endpoints
     ctx.rgw.realm = None
     ctx.rgw.regions = {'region0': { 'api name': 'api1',
-	    'is master': True, 'master zone': 'r0z0',
-	    'zones': ['r0z0', 'r0z1'] }}
+        'is master': True, 'master zone': 'r0z0',
+        'zones': ['r0z0', 'r0z1'] }}
     ctx.rgw.config = {'ceph.client.rgw.%s' % host: {'system user': {'name': '%s-system-user' % host}}}
     task(config, None)
     exit()

--- a/qa/tasks/ragweed.py
+++ b/qa/tasks/ragweed.py
@@ -1,7 +1,7 @@
 """
 Run a set of s3 tests on rgw.
 """
-from cStringIO import StringIO
+from io import BytesIO
 from configobj import ConfigObj
 import base64
 import contextlib
@@ -200,7 +200,7 @@ def configure(ctx, config, run_stages):
         if properties is not None and 'slow_backend' in properties:
             ragweed_conf['fixtures']['slow backend'] = properties['slow_backend']
 
-        conf_fp = StringIO()
+        conf_fp = BytesIO()
         ragweed_conf.write(conf_fp)
         teuthology.write_file(
             remote=remote,

--- a/qa/tasks/ragweed.py
+++ b/qa/tasks/ragweed.py
@@ -155,7 +155,7 @@ def create_users(ctx, config, run_stages):
             if not 'check' in run_stages[client]:
                 # only remove user if went through the check stage
                 continue
-            for user in users.itervalues():
+            for user in users.values():
                 uid = '{user}.{client}'.format(user=user, client=client)
                 ctx.cluster.only(client).run(
                     args=[

--- a/qa/tasks/rbd.py
+++ b/qa/tasks/rbd.py
@@ -7,7 +7,7 @@ import os
 import tempfile
 import sys
 
-from cStringIO import StringIO
+from io import BytesIO
 from teuthology.orchestra import run
 from teuthology import misc as teuthology
 from teuthology import contextutil
@@ -303,12 +303,12 @@ def canonical_path(ctx, role, path):
     representing the given role.  A canonical path contains no
     . or .. components, and includes no symbolic links.
     """
-    version_fp = StringIO()
+    version_fp = BytesIO()
     ctx.cluster.only(role).run(
         args=[ 'readlink', '-f', path ],
         stdout=version_fp,
         )
-    canonical_path = version_fp.getvalue().rstrip('\n')
+    canonical_path = six.ensure_str(version_fp.getvalue()).rstrip('\n')
     version_fp.close()
     return canonical_path
 

--- a/qa/tasks/rgw.py
+++ b/qa/tasks/rgw.py
@@ -9,11 +9,11 @@ from teuthology.orchestra import run
 from teuthology import misc as teuthology
 from teuthology import contextutil
 from teuthology.exceptions import ConfigError
-from util import get_remote_for_role
-from util.rgw import rgwadmin, wait_for_radosgw
-from util.rados import (create_ec_pool,
-                        create_replicated_pool,
-                        create_cache_pool)
+from tasks.util import get_remote_for_role
+from tasks.util.rgw import rgwadmin, wait_for_radosgw
+from tasks.util.rados import (create_ec_pool,
+                              create_replicated_pool,
+                              create_cache_pool)
 
 log = logging.getLogger(__name__)
 

--- a/qa/tasks/rgw_logsocket.py
+++ b/qa/tasks/rgw_logsocket.py
@@ -1,7 +1,7 @@
 """
 rgw s3tests logging wrappers
 """
-from cStringIO import StringIO
+from io import BytesIO
 from configobj import ConfigObj
 import contextlib
 import logging
@@ -68,7 +68,7 @@ def run_tests(ctx, config):
 
     s3tests.run_tests(ctx, config)
 
-    netcat_out = StringIO()
+    netcat_out = BytesIO()
 
     for client, client_config in config.items():
         ctx.cluster.only(client).run(

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -247,13 +247,13 @@ def configure(ctx, config):
     for client, properties in config['clients'].items():
         with open(boto_src, 'rb') as f:
             (remote,) = ctx.cluster.only(client).remotes.keys()
-            conf = f.read().format(
+            conf = six.ensure_str(f.read()).format(
                 idle_timeout=config.get('idle_timeout', 30)
                 )
             teuthology.write_file(
                 remote=remote,
                 path='{tdir}/boto.cfg'.format(tdir=testdir),
-                data=conf,
+                data=six.ensure_binary(conf),
                 )
 
     try:

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -1,13 +1,14 @@
 """
 Run a set of s3 tests on rgw.
 """
-from cStringIO import StringIO
+from io import BytesIO
 from configobj import ConfigObj
 import base64
 import contextlib
 import logging
 import os
 import random
+import six
 import string
 
 from teuthology import misc as teuthology
@@ -78,10 +79,14 @@ def _config_user(s3tests_conf, section, user):
     s3tests_conf[section].setdefault('user_id', user)
     s3tests_conf[section].setdefault('email', '{user}+test@test.test'.format(user=user))
     s3tests_conf[section].setdefault('display_name', 'Mr. {user}'.format(user=user))
-    s3tests_conf[section].setdefault('access_key', ''.join(random.choice(string.uppercase) for i in range(20)))
-    s3tests_conf[section].setdefault('secret_key', base64.b64encode(os.urandom(40)))
-    s3tests_conf[section].setdefault('totp_serial', ''.join(random.choice(string.digits) for i in range(10)))
-    s3tests_conf[section].setdefault('totp_seed', base64.b32encode(os.urandom(40)))
+    s3tests_conf[section].setdefault('access_key',
+        ''.join(random.choice(string.ascii_uppercase) for i in range(20)))
+    s3tests_conf[section].setdefault('secret_key',
+        six.ensure_str(base64.b64encode(os.urandom(40))))
+    s3tests_conf[section].setdefault('totp_serial',
+        ''.join(random.choice(string.digits) for i in range(10)))
+    s3tests_conf[section].setdefault('totp_seed',
+        six.ensure_str(base64.b32encode(os.urandom(40))))
     s3tests_conf[section].setdefault('totp_seconds', '5')
 
 
@@ -141,7 +146,7 @@ def create_users(ctx, config):
         yield
     finally:
         for client in config['clients']:
-            for user in users.itervalues():
+            for user in users.values():
                 uid = '{user}.{client}'.format(user=user, client=client)
                 cluster_name, daemon_type, client_id = teuthology.split_role(client)
                 client_with_id = daemon_type + '.' + client_id
@@ -229,7 +234,7 @@ def configure(ctx, config):
                 './bootstrap',
                 ],
             )
-        conf_fp = StringIO()
+        conf_fp = BytesIO()
         s3tests_conf.write(conf_fp)
         teuthology.write_file(
             remote=remote,

--- a/qa/tasks/s3tests_java.py
+++ b/qa/tasks/s3tests_java.py
@@ -1,7 +1,7 @@
 """
 Task for running RGW S3 tests with the AWS Java SDK
 """
-from cStringIO import StringIO
+from io import BytesIO
 import logging
 
 import base64
@@ -117,7 +117,7 @@ class S3tests_java(Task):
                 repo,
                 '{tdir}/s3-tests-java'.format(tdir=testdir),
             ],
-            stdout=StringIO()
+            stdout=BytesIO()
         )
         if client in self.config and self.config[client] is not None:
             if 'sha1' in self.config[client] and self.config[client]['sha1'] is not None:
@@ -156,7 +156,7 @@ class S3tests_java(Task):
         testdir = teuthology.get_testdir(self.ctx)
         self.ctx.cluster.only(client).run(
             args=['{tdir}/s3-tests-java/bootstrap.sh'.format(tdir=testdir)],
-            stdout=StringIO()
+            stdout=BytesIO()
         )
 
         endpoint = self.ctx.rgw.role_endpoints[client]
@@ -173,7 +173,7 @@ class S3tests_java(Task):
                       '-file', endpoint.cert.certificate,
                       '-storepass', 'changeit',
                       ],
-                stdout=StringIO()
+                stdout=BytesIO()
             )
 
     def create_users(self):
@@ -224,7 +224,7 @@ class S3tests_java(Task):
                     log.info('{args}'.format(args=args))
                     self.ctx.cluster.only(client).run(
                         args=args,
-                        stdout=StringIO()
+                        stdout=BytesIO()
                     )
                 else:
                     self.users.pop(section)
@@ -279,8 +279,8 @@ class S3tests_java(Task):
         with open('s3_tests_tmp.yaml', 'w') as outfile:
             yaml.dump(cfg_dict, outfile, default_flow_style=False)
 
-        conf_fp = StringIO()
-        with open('s3_tests_tmp.yaml', 'r') as infile:
+        conf_fp = BytesIO()
+        with open('s3_tests_tmp.yaml', 'rb') as infile:
             for line in infile:
                 conf_fp.write(line)
 
@@ -309,7 +309,7 @@ class S3tests_java(Task):
                       '{tdir}/s3-tests-java/config.properties'.format(
                           tdir=testdir)
                       ],
-                stdout=StringIO()
+                stdout=BytesIO()
             )
             args = ['cd',
                     '{tdir}/s3-tests-java'.format(tdir=testdir),
@@ -346,25 +346,25 @@ class S3tests_java(Task):
                     self.ctx.cluster.only(client).run(
                         args=['radosgw-admin', 'gc',
                               'process', '--include-all'],
-                        stdout=StringIO()
+                        stdout=BytesIO()
                     )
 
                 if gr != 'All':
                     self.ctx.cluster.only(client).run(
                         args=args + ['--tests'] + [gr] + extra_args,
-                        stdout=StringIO()
+                        stdout=BytesIO()
                     )
                 else:
                     self.ctx.cluster.only(client).run(
                         args=args + extra_args,
-                        stdout=StringIO()
+                        stdout=BytesIO()
                     )
 
                 for i in range(2):
                     self.ctx.cluster.only(client).run(
                         args=['radosgw-admin', 'gc',
                               'process', '--include-all'],
-                        stdout=StringIO()
+                        stdout=BytesIO()
                     )
 
     def remove_tests(self, client):
@@ -379,7 +379,7 @@ class S3tests_java(Task):
                       'cat', self.log_name,
                       run.Raw('&&'),
                       'rm', self.log_name],
-                stdout=StringIO()
+                stdout=BytesIO()
             )
 
         self.ctx.cluster.only(client).run(
@@ -388,7 +388,7 @@ class S3tests_java(Task):
                 '-rf',
                 '{tdir}/s3-tests-java'.format(tdir=testdir),
             ],
-            stdout=StringIO()
+            stdout=BytesIO()
         )
 
     def delete_users(self, client):
@@ -408,7 +408,7 @@ class S3tests_java(Task):
                     '--purge-data',
                     '--cluster', 'ceph',
                 ],
-                stdout=StringIO()
+                stdout=BytesIO()
             )
 
 

--- a/qa/tasks/scrub.py
+++ b/qa/tasks/scrub.py
@@ -7,7 +7,7 @@ import logging
 import random
 import time
 
-import ceph_manager
+import tasks.ceph_manager
 from teuthology import misc as teuthology
 
 log = logging.getLogger(__name__)

--- a/qa/tasks/systemd.py
+++ b/qa/tasks/systemd.py
@@ -6,12 +6,15 @@ import logging
 import re
 import time
 
-from cStringIO import StringIO
 from teuthology.orchestra import run
 from teuthology.misc import reconnect, get_first_mon, wait_until_healthy
 
 log = logging.getLogger(__name__)
 
+def _remote_service_status(remote, service):
+    status = remote.sh('sudo systemctl status %s' % service,
+                       check_status=False)
+    return status
 
 @contextlib.contextmanager
 def task(ctx, config):
@@ -26,11 +29,10 @@ def task(ctx, config):
     for remote, roles in ctx.cluster.remotes.items():
         remote.run(args=['sudo', 'ps', '-eaf', run.Raw('|'),
                          'grep', 'ceph'])
-        r = remote.run(args=['sudo', 'systemctl', 'list-units', run.Raw('|'),
-                             'grep', 'ceph'], stdout=StringIO(),
-                       check_status=False)
-        log.info(r.stdout.getvalue())
-        if r.stdout.getvalue().find('failed'):
+        units = remote.sh('sudo systemctl list-units | grep ceph',
+                          check_status=False)
+        log.info(units)
+        if units.find('failed'):
             log.info("Ceph services in failed state")
 
         # test overall service stop and start using ceph.target
@@ -38,29 +40,25 @@ def task(ctx, config):
         # and not actual process testing using 'ps'
         log.info("Stopping all Ceph services")
         remote.run(args=['sudo', 'systemctl', 'stop', 'ceph.target'])
-        r = remote.run(args=['sudo', 'systemctl', 'status', 'ceph.target'],
-                       stdout=StringIO(), check_status=False)
-        log.info(r.stdout.getvalue())
+        status = _remote_service_status(remote, 'ceph.target')
+        log.info(status)
         log.info("Checking process status")
-        r = remote.run(args=['sudo', 'ps', '-eaf', run.Raw('|'),
-                             'grep', 'ceph'], stdout=StringIO())
-        if r.stdout.getvalue().find('Active: inactive'):
+        ps_eaf = remote.sh('sudo ps -eaf | grep ceph')
+        if ps_eaf.find('Active: inactive'):
             log.info("Successfully stopped all ceph services")
         else:
             log.info("Failed to stop ceph services")
 
         log.info("Starting all Ceph services")
         remote.run(args=['sudo', 'systemctl', 'start', 'ceph.target'])
-        r = remote.run(args=['sudo', 'systemctl', 'status', 'ceph.target'],
-                       stdout=StringIO())
-        log.info(r.stdout.getvalue())
-        if r.stdout.getvalue().find('Active: active'):
+        status = _remote_service_status(remote, 'ceph.target')
+        log.info(status)
+        if status.find('Active: active'):
             log.info("Successfully started all Ceph services")
         else:
             log.info("info", "Failed to start Ceph services")
-        r = remote.run(args=['sudo', 'ps', '-eaf', run.Raw('|'),
-                             'grep', 'ceph'], stdout=StringIO())
-        log.info(r.stdout.getvalue())
+        ps_eaf = remote.sh('sudo ps -eaf | grep ceph')
+        log.info(ps_eaf)
         time.sleep(4)
 
         # test individual services start stop
@@ -79,23 +77,20 @@ def task(ctx, config):
             remote.run(args=['sudo', 'systemctl', 'stop',
                              osd_service])
             time.sleep(4)  # immediate check will result in deactivating state
-            r = remote.run(args=['sudo', 'systemctl', 'status', osd_service],
-                           stdout=StringIO(), check_status=False)
-            log.info(r.stdout.getvalue())
-            if r.stdout.getvalue().find('Active: inactive'):
+            status = _remote_service_status(remote, osd_service)
+            log.info(status)
+            if status.find('Active: inactive'):
                 log.info("Successfully stopped single osd ceph service")
             else:
                 log.info("Failed to stop ceph osd services")
-            remote.run(args=['sudo', 'systemctl', 'start',
-                             osd_service])
+            remote.sh(['sudo', 'systemctl', 'start', osd_service])
             time.sleep(4)
         if mon_role_name in roles:
             remote.run(args=['sudo', 'systemctl', 'status', mon_name])
             remote.run(args=['sudo', 'systemctl', 'stop', mon_name])
             time.sleep(4)  # immediate check will result in deactivating state
-            r = remote.run(args=['sudo', 'systemctl', 'status', mon_name],
-                           stdout=StringIO(), check_status=False)
-            if r.stdout.getvalue().find('Active: inactive'):
+            status = _remote_service_status(remote, mon_name)
+            if status.find('Active: inactive'):
                 log.info("Successfully stopped single mon ceph service")
             else:
                 log.info("Failed to stop ceph mon service")
@@ -105,9 +100,8 @@ def task(ctx, config):
             remote.run(args=['sudo', 'systemctl', 'status', mgr_name])
             remote.run(args=['sudo', 'systemctl', 'stop', mgr_name])
             time.sleep(4)  # immediate check will result in deactivating state
-            r = remote.run(args=['sudo', 'systemctl', 'status', mgr_name],
-                           stdout=StringIO(), check_status=False)
-            if r.stdout.getvalue().find('Active: inactive'):
+            status = _remote_service_status(remote, mgr_name)
+            if status.find('Active: inactive'):
                 log.info("Successfully stopped single ceph mgr service")
             else:
                 log.info("Failed to stop ceph mgr service")
@@ -117,9 +111,8 @@ def task(ctx, config):
             remote.run(args=['sudo', 'systemctl', 'status', mds_name])
             remote.run(args=['sudo', 'systemctl', 'stop', mds_name])
             time.sleep(4)  # immediate check will result in deactivating state
-            r = remote.run(args=['sudo', 'systemctl', 'status', mds_name],
-                           stdout=StringIO(), check_status=False)
-            if r.stdout.getvalue().find('Active: inactive'):
+            status = _remote_service_status(remote, mds_name)
+            if status.find('Active: inactive'):
                 log.info("Successfully stopped single ceph mds service")
             else:
                 log.info("Failed to stop ceph mds service")

--- a/qa/tasks/thrashosds.py
+++ b/qa/tasks/thrashosds.py
@@ -3,7 +3,7 @@ Thrash -- Simulate random osd failures.
 """
 import contextlib
 import logging
-import ceph_manager
+from tasks import ceph_manager
 from teuthology import misc as teuthology
 
 

--- a/qa/tasks/util/rgw.py
+++ b/qa/tasks/util/rgw.py
@@ -1,4 +1,4 @@
-from cStringIO import StringIO
+from io import BytesIO
 import logging
 import json
 import time
@@ -7,7 +7,7 @@ from teuthology import misc as teuthology
 
 log = logging.getLogger(__name__)
 
-def rgwadmin(ctx, client, cmd, stdin=StringIO(), check_status=False,
+def rgwadmin(ctx, client, cmd, stdin=BytesIO(), check_status=False,
              format='json', decode=True, log_level=logging.DEBUG):
     log.info('rgwadmin: {client} : {cmd}'.format(client=client,cmd=cmd))
     testdir = teuthology.get_testdir(ctx)
@@ -29,8 +29,8 @@ def rgwadmin(ctx, client, cmd, stdin=StringIO(), check_status=False,
     proc = remote.run(
         args=pre,
         check_status=check_status,
-        stdout=StringIO(),
-        stderr=StringIO(),
+        stdout=BytesIO(),
+        stderr=BytesIO(),
         stdin=stdin,
         )
     r = proc.exitstatus
@@ -81,9 +81,9 @@ def wait_for_radosgw(url, remote):
         proc = remote.run(
             args=curl_cmd,
             check_status=False,
-            stdout=StringIO(),
-            stderr=StringIO(),
-            stdin=StringIO(),
+            stdout=BytesIO(),
+            stderr=BytesIO(),
+            stdin=BytesIO(),
             )
         exit_status = proc.exitstatus
         if exit_status == 0:

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -30,7 +30,7 @@ Alternative usage:
 
 """
 
-from six import StringIO
+from six import BytesIO
 from collections import defaultdict
 import getpass
 import signal
@@ -154,12 +154,12 @@ class LocalRemoteProcess(object):
         self.args = args
         self.subproc = subproc
         if stdout is None:
-            self.stdout = StringIO()
+            self.stdout = BytesIO()
         else:
             self.stdout = stdout
 
         if stderr is None:
-            self.stderr = StringIO()
+            self.stderr = BytesIO()
         else:
             self.stderr = stderr
 
@@ -931,7 +931,7 @@ class LocalCephManager(CephManager):
         if watch_channel is not None:
             args.append("--watch-channel")
             args.append(watch_channel)
-        proc = self.controller.run(args, wait=False, stdout=StringIO())
+        proc = self.controller.run(args, wait=False, stdout=BytesIO())
         return proc
 
     def raw_cluster_cmd(self, *args, **kwargs):

--- a/qa/tasks/watch_notify_same_primary.py
+++ b/qa/tasks/watch_notify_same_primary.py
@@ -2,7 +2,7 @@
 """
 watch_notify_same_primary task
 """
-from cStringIO import StringIO
+from io import BytesIO
 import contextlib
 import logging
 
@@ -68,8 +68,8 @@ def task(ctx, config):
                 "watch",
                 obj(n)],
             stdin=run.PIPE,
-            stdout=StringIO(),
-            stderr=StringIO(),
+            stdout=BytesIO(),
+            stderr=BytesIO(),
             wait=False)
         return proc
 
@@ -81,14 +81,8 @@ def task(ctx, config):
     for i in range(num):
         with safe_while() as proceed:
             while proceed():
-                proc = remote.run(
-                    args = [
-                        "rados",
-                        "-p", pool,
-                        "listwatchers",
-                        obj(i)],
-                    stdout=StringIO())
-                lines = proc.stdout.getvalue()
+                lines = remote.sh(
+                    ["rados", "-p", pool, "listwatchers", obj(i)])
                 num_watchers = lines.count('watcher=')
                 log.info('i see %d watchers for %s', num_watchers, obj(i))
                 if num_watchers >= 1:

--- a/qa/tasks/watch_notify_stress.py
+++ b/qa/tasks/watch_notify_stress.py
@@ -66,5 +66,5 @@ def task(ctx, config):
         yield
     finally:
         log.info('joining watch_notify_stress')
-        for i in testwatch.itervalues():
+        for i in testwatch.values():
             i.join()

--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -8,8 +8,8 @@ import re
 
 import six
 
-from util import get_remote_for_role
-from util.workunit import get_refspec_after_overrides
+from tasks.util import get_remote_for_role
+from tasks.util.workunit import get_refspec_after_overrides
 
 from teuthology import misc
 from teuthology.config import config as teuth_config

--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -364,7 +364,7 @@ def _run_tests(ctx, refspec, role, tests, env, basedir,
     )
 
     workunits_file = '{tdir}/workunits.list.{role}'.format(tdir=testdir, role=role)
-    workunits = sorted(misc.get_file(remote, workunits_file).split('\0'))
+    workunits = sorted(six.ensure_str(misc.get_file(remote, workunits_file)).split('\0'))
     assert workunits
 
     try:


### PR DESCRIPTION
as expected by "qa/tasks/cephfs: get rid of StringIO for py3"

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
